### PR TITLE
Implement dynamic baseline for Policy Gradient phase

### DIFF
--- a/src/Ablated_TT_Experiment.md
+++ b/src/Ablated_TT_Experiment.md
@@ -1,0 +1,196 @@
+### **Details: Ablated Time Travel Experiment**
+
+The **Ablated Time Travel Experiment** is designed to investigate how well the model can rewrite story endings based on counterfactual events **without including the original ending** in the input. 
+
+#### **Key Differences**
+- In the **TimeTravel** dataset, the input includes:
+  - `Premise`, `Initial Event`, `Original Ending`, and `Counterfactual Event`.
+- In the **Ablated TimeTravel** experiment, the input excludes the **Original Ending** and includes only:
+  - `Premise`, `Initial Event`, and `Counterfactual Event`.
+
+#### **Goal**
+Evaluate how removing the `Original Ending` from the input affects the quality of the rewritten ending. The outputs (`Edited Ending`) are still compared to the ground-truth reference.
+
+---
+
+### **Code Changes for Ablated TimeTravel Experiment**
+
+#### **Step 1: Update the `preprocess_data` Function**
+Modify the `preprocess_data` function to handle the **AblatedTimeTravel** dataset by excluding the `Original Ending` from the input sequence.
+
+```python
+def preprocess_data(row, tokenizer, dataset_type="TimeTravel"):
+    """
+    Prepares a single row of data for model input by tokenizing the text fields.
+
+    Args:
+        row (dict): A single row of data containing the fields required for the input.
+        tokenizer (Tokenizer): The tokenizer to use for tokenizing the text fields.
+        dataset_type (str): Specifies the type of dataset to determine preprocessing logic.
+            Options: "ART", "TimeTravel", "AblatedTimeTravel".
+
+    Returns:
+        dict: A dictionary containing tokenized input, attention masks, and labels.
+    """
+    try:
+        separator_token = "</s>"
+
+        if dataset_type == "AblatedTimeTravel":
+            # Exclude 'Original Ending' from input
+            input_sequence = (
+                f"{row['premise']} "
+                f"{row['initial']} {separator_token} "
+                f"{row['premise']} {row['counterfactual']}"
+            )
+            target_sequence = row['edited_ending']
+            print(f"Input Sequence (AblatedTimeTravel): {input_sequence}")
+            print(f"Target Sequence: {target_sequence}")
+
+        elif dataset_type == "TimeTravel":
+            # Include 'Original Ending' in the input
+            input_sequence = (
+                f"{row['premise']} "
+                f"{row['initial']} "
+                f"{row['original_ending']} {separator_token} "
+                f"{row['premise']} {row['counterfactual']}"
+            )
+            target_sequence = row['edited_ending']
+            print(f"Input Sequence (TimeTravel): {input_sequence}")
+            print(f"Target Sequence: {target_sequence}")
+
+        elif dataset_type == "ART":
+            input_sequence = (
+                f"{row['premise']} "
+                f"{row['initial']} {separator_token} "
+                f"{row['premise']} {row['counterfactual']}"
+            )
+            target_sequence = row['edited_ending']
+            print(f"Input Sequence (ART): {input_sequence}")
+            print(f"Target Sequence: {target_sequence}")
+
+        else:
+            raise ValueError(f"Unsupported dataset type: {dataset_type}")
+
+        # Tokenize the input sequence
+        tokenized_inputs = tokenizer.encode_plus(
+            input_sequence, truncation=True, return_tensors="pt", max_length=CONFIG["max_length"]
+        )
+
+        # Tokenize the target sequence (Edited Ending)
+        tokenized_ending = tokenizer.encode_plus(
+            target_sequence, truncation=True, return_tensors="pt", max_length=CONFIG["max_length"]
+        )
+
+        # Prepare the final output dictionary
+        return {
+            'input_ids': tokenized_inputs['input_ids'].squeeze(0),
+            'attention_mask': tokenized_inputs['attention_mask'].squeeze(0),
+            'labels': tokenized_ending['input_ids'].squeeze(0),
+            'premise': row['premise'],
+            'initial': row['initial'],
+            'counterfactual': row['counterfactual'],
+            'edited_ending': row['edited_ending'],
+            **({'original_ending': row['original_ending']} if 'original_ending' in row else {})
+        }
+
+    except Exception as e:
+        logger.error(f"Error in preprocess_data: {e}")
+        return None
+```
+
+---
+
+#### **Step 2: Modify the `create_dataloaders` Function**
+Ensure the `dataset_type` is correctly passed as `AblatedTimeTravel` when loading the dataset.
+
+```python
+def create_dataloaders(data_path, tokenizer, batch_size, num_workers, dataset_type="TimeTravel"):
+    """
+    Creates DataLoader instances for each dataset specified by the configuration.
+
+    Args:
+        data_path (str): Path to the base directory containing data files.
+        tokenizer (T5Tokenizer): The tokenizer to use for preprocessing the data.
+        batch_size (int): The number of samples per batch.
+        num_workers (int): The number of worker threads to use for loading data.
+        dataset_type (str): Specifies the dataset type (e.g., "ART", "TimeTravel", "AblatedTimeTravel").
+
+    Returns:
+        dict: A dictionary of DataLoader objects, keyed by dataset type ('train', 'dev', 'test').
+    """
+    print(f"Creating dataloaders for dataset_type: {dataset_type}")  # Debug dataset type
+
+    file_names = [CONFIG["train_file"], CONFIG["dev_file"], CONFIG["test_file"]]
+
+    dataloaders = {}
+    for file_name in file_names:
+        file_path = Path(data_path) / file_name
+        print(f"Loading file: {file_path} for dataset_type: {dataset_type}")  # Debug file path
+        if not file_path.exists():
+            raise FileNotFoundError(f"{file_path} does not exist.")
+        
+        # Create an instance of the dataset for each data file
+        dataset = CustomJSONDataset(file_path, tokenizer, dataset_type=dataset_type)
+
+        # Determine whether to shuffle: shuffle only for training
+        shuffle = file_name == CONFIG["train_file"]
+
+        # Create a DataLoader for each dataset
+        dataloader = DataLoader(
+            dataset,
+            batch_size=batch_size,
+            collate_fn=lambda batch: collate_fn(batch, pad_token_id=tokenizer.pad_token_id),
+            num_workers=num_workers,
+            shuffle=shuffle
+        )
+
+        # Use the file name (without extension) as the key
+        key = file_name.split('.')[0]
+        dataloaders[key] = dataloader
+
+    return dataloaders
+```
+
+---
+
+#### **Step 3: Add AblatedTimeTravel Experiment in Main Script**
+When setting up the model and training workflow, pass `dataset_type="AblatedTimeTravel"` to `create_dataloaders`.
+
+```python
+if CONFIG["dataset_type"] == "AblatedTimeTravel":
+    print("Running Ablated TimeTravel Experiment...")
+    dataloaders = create_dataloaders(
+        data_path=CONFIG["data_dir"],
+        tokenizer=tokenizer,
+        batch_size=CONFIG["batch_size"],
+        num_workers=CONFIG["num_workers"],
+        dataset_type="AblatedTimeTravel"
+    )
+```
+
+---
+
+#### **Step 4: Update Configuration**
+In the `CONFIG` file, set `dataset_type` to `AblatedTimeTravel` for this experiment.
+
+```python
+CONFIG = {
+    ...
+    "dataset_type": "AblatedTimeTravel",
+    ...
+}
+```
+
+---
+
+### **Summary of Changes**
+1. **Modified `preprocess_data`**:
+   - Added logic to exclude `Original Ending` for `AblatedTimeTravel`.
+2. **Updated `create_dataloaders`**:
+   - Pass `AblatedTimeTravel` as the `dataset_type`.
+3. **Main Script Update**:
+   - Added conditional logic for running the Ablated TimeTravel experiment.
+4. **Configuration Update**:
+   - Added `AblatedTimeTravel` as a dataset type in the configuration.
+
+This will enable the model to process the AblatedTimeTravel dataset and evaluate the impact of excluding the `Original Ending` during story rewriting. Let me know if you need further assistance!

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -10,7 +10,7 @@ class CustomJSONDataset(Dataset):
     A custom PyTorch Dataset class designed for loading and preprocessing data stored in JSON format.
     Supports tokenization and preprocessing for model training and evaluation.
     """
-    def __init__(self, file_path, tokenizer, dataset_type="TimeTravel"):
+    def __init__(self, file_path, tokenizer):
         """
         Initializes the dataset object.
 
@@ -18,6 +18,7 @@ class CustomJSONDataset(Dataset):
             file_path (str): Path to the JSON file containing the data.
             tokenizer (T5Tokenizer): The tokenizer to use for preprocessing.
         """
+        dataset_type = CONFIG["dataset_type"]  # Fetch dataset_type directly from CONFIG
         print(f"Initializing CustomJSONDataset with dataset_type: {dataset_type}")
         # Attempt to load and preprocess the data from the provided JSON file
         try:
@@ -27,11 +28,16 @@ class CustomJSONDataset(Dataset):
         except FileNotFoundError:
             raise FileNotFoundError(f"File not found: {file_path}")
 
+        # Store tokenizer and dataset type
         self.tokenizer = tokenizer
         self.data_type = dataset_type
 
         # Preprocess each row of the data using the provided tokenizer
-        self.processed_data = data.apply(lambda row: preprocess_data(row, self.tokenizer, dataset_type=dataset_type), axis=1, result_type='expand')
+        self.processed_data = data.apply(
+            lambda row: preprocess_data(row, self.tokenizer),
+            axis=1,
+            result_type='expand'
+        )
         print(f"First few rows of processed data: {self.processed_data.head()}")
 
     def __len__(self):
@@ -51,7 +57,7 @@ class CustomJSONDataset(Dataset):
         item = self.processed_data.iloc[idx]
         return item
 
-def create_dataloaders(data_path, tokenizer, batch_size, num_workers, dataset_type="TimeTravel"):
+def create_dataloaders(data_path, tokenizer, batch_size, num_workers):
     """
     Creates DataLoader instances for each dataset specified by the configuration.
 
@@ -60,25 +66,30 @@ def create_dataloaders(data_path, tokenizer, batch_size, num_workers, dataset_ty
         tokenizer (T5Tokenizer): The tokenizer to use for preprocessing the data.
         batch_size (int): The number of samples per batch.
         num_workers (int): The number of worker threads to use for loading data.
-        dataset_type (str): Specifies the dataset tpe (eg. "ART", "TimeTravel","AblatedTimeTravel").
 
     Returns:
         dict: A dictionary of DataLoader objects, keyed by dataset type ('train', 'dev', 'test').
     """
-
+    dataset_type = CONFIG["dataset_type"] # Access dataset_type from CONFIG "ART", "TimeTravel", "AblatedTimeTravel".
     print(f"Creating dataloaders for dataset_type: {dataset_type}")  # Debug dataset type
 
-    file_names = [CONFIG["train_file"], CONFIG["dev_file"], CONFIG["test_file"]]
+    file_names = [
+        CONFIG["train_file"],
+        CONFIG["dev_file"],
+        CONFIG["test_file"]
+    ]
 
     dataloaders = {}
     for file_name in file_names:
         file_path = Path(data_path) / file_name
         print(f"Loading file: {file_path} for dataset_type: {dataset_type}")  # Debug file path
+
+        # Check if the dataset file exists
         if not file_path.exists():
             raise FileNotFoundError(f"{file_path} does not exist.")
         
         # Create an instance of the dataset for each data file
-        dataset = CustomJSONDataset(file_path, tokenizer, dataset_type=dataset_type)
+        dataset = CustomJSONDataset(file_path, tokenizer)
 
         # Determine whether to shuffle: shuffle only for training
         shuffle = file_name == CONFIG["train_file"]

--- a/src/main.py
+++ b/src/main.py
@@ -190,8 +190,7 @@ def main():
         CONFIG["data_dir"], 
         tokenizer, 
         CONFIG["batch_size"], 
-        CONFIG["num_workers"], 
-        dataset_type=dataset_type  # Explicitly pass the dataset_type
+        CONFIG["num_workers"],
     )
     train_key, dev_key, test_key = CONFIG["train_file"].split('.')[0], CONFIG["dev_file"].split('.')[0], CONFIG["test_file"].split('.')[0]
 
@@ -297,8 +296,6 @@ def main():
                 best_epoch=best_epoch,
                 phase="validation"
             )
-            
-
 
 if __name__ == '__main__':
     logger.info("Starting the main process...")

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -15,15 +15,16 @@ CONFIG = {
     "results_dir": ROOT_DIR / "results",  # Directory for results (e.g., validation details)
     "dataset_type": "TimeTravel",  # Options: "ART", "TimeTravel", "AblatedTimeTravel"
 
+    # ******** Data files***********
     # Sample Timetravel sample datasets
     #"train_file": "train_supervised_small_sample.json",
     #"dev_file": "dev_data_sample.json",
     #"test_file": "test_data_sample.json",
 
-    # Timetravel  datasets
-    "train_file": "train_supervised_small_sample.json",
-    "dev_file": "dev_data_sample.json",
-    "test_file": "test_data_sample.json",
+    # Timetravel,AblatedTimeTravel datasets
+    "train_file": "train_supervised_small.json",
+    "dev_file": "dev_data.json",
+    "test_file": "test_data.json",
 
     # Sample Art dataset
     #"train_file": "art_train_data_sample.json",
@@ -50,23 +51,29 @@ CONFIG = {
     "use_custom_loss": False,  # Whether to use a custom loss function (set to False for MLE)
     "output_attentions": False,  # Set to True to output attentions from the model (optional)
 
-    # MLE Phase configurations
+    # MLE Training
     "mle_enabled": False,  # Enable MLE training
-    "mle_from_checkpoint": False,  # Start training from scratch (no checkpoint)
-    "mle_checkpoint_path": None,  # No checkpoint path since we start from scratch
+    "mle_from_checkpoint": True,   # Set to True to resume training from the specified mle_checkpoint_path; False starts training from scratch.
+    "mle_checkpoint_path": '/home/agirard/Data/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-28-11/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=2.04.ckpt',  # MLE3_1-1_Ablated-TT
     "mle_epochs": 3,  # Number of epochs to train with MLE
 
-    # PG Phase configurations (disabled in this experiment)
-    "pg_enabled": True,  # Disable policy gradient training (PG phase)
-    "pg_from_checkpoint": True,  # Start PG training from the best MLE checkpoint, not a separate checkpoint
-    #"pg_checkpoint_path": '/home/agirard/Data/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-22-14/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.95.ckpt',# MLE3_10-1
-    #"pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-15-12/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.90.ckpt',   # MLE3_5-1
-    "pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2024-12-03-15/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.88.ckpt',   # MLE3_1-1
+    # PG Training
+    "pg_enabled": True,  # Set to True to enable policy gradient (PG) training; False disables it.
+    "pg_from_checkpoint": True,  # If True, PG training starts from the specified pg_checkpoint_path;
+                              # If False, PG training starts from the best MLE checkpoint.
+    #"pg_checkpoint_path": '/home/agirard/Data/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-22-14/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.95.ckpt',# MLE3_10-1_TT
+    #"pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-15-12/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.90.ckpt',   # MLE3_5-1_TT
+    "pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2024-12-03-15/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.88.ckpt',   # MLE3_1-1_TT
+    # "pg_checkpoint_path": '/home/agirard/Data/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-28-11/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=2.04.ckpt',  # MLE3_1-1_Ablated-TT
     "pg_epochs": 3,  # Number of epochs to fine-tune with PG
 
-    # PG Phase Reward-based training configurations
-    "reward_metric": "bart",   ## Primary reward metric for PG (e.g., "rouge", "bert", "bart","bleu") (default to "rouge")
-    "baseline_score": 0.5,  # Baseline score for PG (used to calculate rewards)
+    # Additional configuration for scoring metrics
+    "reward_metric": "bart",   # "rouge","bart", "bert","bleu" (default to "rouge")
+
+    # **Experiment Selection**
+    "pg_experiment": "delta_m1",  # Options: "fixed", "dynamic", "delta_m1"
+    "baseline_score": 0.5,  # Used for PG fixed baseline experiment
+    "delta_m1_enabled": True,  # Enable Delta_M1 reward adjustments
   
     # Additional configuration for scoring metrics 
     "use_bert": True,  # Disable BERT scorer
@@ -75,7 +82,7 @@ CONFIG = {
     "bert_scorer_batch_size": 4,  # Batch size for BERT scorer 
 
     "use_bleu": True,  # Disable BLEU scorer,
-       
+
     "use_bart": True,  # Disable BART scorer
     "bart_scorer_checkpoint": "facebook/bart-large-cnn"  # Default BART model for scorer 
 }

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -21,9 +21,9 @@ CONFIG = {
     #"test_file": "test_data_sample.json",
 
     # Timetravel  datasets
-    "train_file": "train_supervised_small.json",
-    "dev_file": "dev_data.json",
-    "test_file": "test_data.json", 
+    "train_file": "train_supervised_small_sample.json",
+    "dev_file": "dev_data_sample.json",
+    "test_file": "test_data_sample.json",
 
     # Sample Art dataset
     #"train_file": "art_train_data_sample.json",
@@ -47,7 +47,7 @@ CONFIG = {
     "max_gen_length": 250,  # Maximum length for generated text
 
     # Additional training options
-    "use_custom_loss": True,  # Whether to use a custom loss function (set to False for MLE)
+    "use_custom_loss": False,  # Whether to use a custom loss function (set to False for MLE)
     "output_attentions": False,  # Set to True to output attentions from the model (optional)
 
     # MLE Phase configurations
@@ -59,9 +59,9 @@ CONFIG = {
     # PG Phase configurations (disabled in this experiment)
     "pg_enabled": True,  # Disable policy gradient training (PG phase)
     "pg_from_checkpoint": True,  # Start PG training from the best MLE checkpoint, not a separate checkpoint
-    "pg_checkpoint_path": '/home/agirard/Data/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-22-14/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.95.ckpt',# MLE3_10-1
+    #"pg_checkpoint_path": '/home/agirard/Data/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-22-14/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.95.ckpt',# MLE3_10-1
     #"pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2025-01-15-12/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.90.ckpt',   # MLE3_5-1
-    #"pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2024-12-03-15/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.88.ckpt',   # MLE3_1-1
+    "pg_checkpoint_path": '/data/agirard/Projects/TimeTravel-PolicyGradientRL/models/mle_2024-12-03-15/mle_checkpoint_epoch=epoch=2-val_loss=validation_mle_loss=0.88.ckpt',   # MLE3_1-1
     "pg_epochs": 3,  # Number of epochs to fine-tune with PG
 
     # PG Phase Reward-based training configurations

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -37,7 +37,7 @@ def load_first_line_from_json(file_path):
         logger.error(f"Error reading from {file_path}: {e}")
         raise IOError(f"Error reading from {file_path}: {e}")
 
-def calculate_differential_weights(tokenized_labels, tokenizer, differences, high_weight=10, base_weight=1):
+def calculate_differential_weights(tokenized_labels, tokenizer, differences, high_weight=1, base_weight=1):
         """
         Calculate differential weights for tokenized labels (edited endings) based on diff
         erences.

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -55,20 +55,19 @@ def calculate_differential_weights(tokenized_labels, tokenizer, differences, hig
         
         return differential_weights    
 
-def preprocess_data(row, tokenizer, dataset_type="TimeTravel"):
+def preprocess_data(row, tokenizer):
     """
     Prepares a single row of data for model input by tokenizing the text fields.
 
     Args:
         row (dict): A single row of data containing the fields required for the input.
         tokenizer (Tokenizer): The tokenizer to use for tokenizing the text fields.
-        dataset_type (str): Specifies the type of dataset to determine preprocessing logic.
-            Options: "ART", "TimeTravel", "AblatedTimeTravel".
 
     Returns:
         dict: A dictionary containing tokenized input, attention masks, and labels.
     """
     try:
+        dataset_type = CONFIG["dataset_type"]  # Access dataset_type from CONFIG
         separator_token = "</s>"
 
         if dataset_type in {"ART", "AblatedTimeTravel"}:


### PR DESCRIPTION
Hi Inigo,  

I’ve made the updates to implement the dynamic baseline. The changes are in the `model.py` file, where I’ve updated to calculate and apply a batch-specific dynamic baseline for the Policy Gradient (PG) phase.  

Here’s a quick summary of what I’ve done:  
- Modified the **training**, **validation**, and **test steps** to dynamically compute the baseline as the mean BART score for each batch.  
- Adjusted the reward calculations to use the difference between the batch scores and the dynamic baseline.  
- Added logging for the dynamic baseline during training, validation, and testing to make it easier to track in WandB.  

I've tested the changes on a sample dataset, and at first glance, the quality of the generated text appears to have improved.

Thanks!  